### PR TITLE
Bugfix/prop pattern should exclude false

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,7 @@ module.exports = {
     '@babel/plugin-proposal-optional-chaining',
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-do-expressions',
-    ['@babel/transform-runtime'],
+    '@babel/transform-runtime',
     'pipe-composition'
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bupa-digital/shades",
   "author": "Bupa Digital Australia - Front-End Team <npm-digital@bupa.com.au>",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "homepage": "https://github.com/bupa-digital/shades",
   "repository": "https://github.com/bupa-digital/shades",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postversion": "git push --tags"
   },
   "devDependencies": {
+    "@babel/core": "7.1.2",
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-proposal-decorators": "7.1.2",
     "@babel/plugin-proposal-do-expressions": "7.0.0",
@@ -72,7 +73,6 @@
     "recompose": "^0.26.0"
   },
   "dependencies": {
-    "@babel/core": "7.1.2",
     "@babel/runtime": "7.1.2",
     "autoprefixer": "^7.2.1",
     "crocks": "^0.9.4",

--- a/src/style-parser.js
+++ b/src/style-parser.js
@@ -7,6 +7,8 @@ import {
 import {
   dasherize,
   when,
+  not,
+  isFalsy,
   valueAsFunction,
   isObjectLiteral,
   isArray,
@@ -33,7 +35,6 @@ import {
 } from './utilities/config';
 
 import {
-  not,
   curry,
   compose,
   startsWith,
@@ -61,7 +62,8 @@ import {
   forEach,
   all,
   type,
-  always
+  always,
+  prop
 } from 'ramda';
 
 import autoprefixer from 'autoprefixer';
@@ -145,6 +147,11 @@ const findKeyForValue = (needle, fallback) => (haystack) => (
   defaultTo([fallback, true]) |>
   firstItem
 );
+
+const propExistsAndPasses = (name, predicate) => (original) => (
+  (original |> has(name)) &&
+  (original |> prop(name) |> predicate)
+)
 
 // Can iterate over arrays or object literals. Will call conputeFn
 // on each item or key/value pair in the data until the computeFn
@@ -361,7 +368,7 @@ export const parseAllStyles = parseStyleMetaData({
   propertyMatch: ({ parseNested, parentSelector, props, propExists }) => (key, value) => {
     const propName = key |> stripPropertyBangs;
 
-    if (propName |> propExists) return (
+    if (props |> propExistsAndPasses(propName, not(isUndefinedOrFalse))) return (
       value
       |> whenFunctionCallWith(props[propName])
       |> parseNested(parentSelector)

--- a/src/style-parser.spec.js
+++ b/src/style-parser.spec.js
@@ -270,6 +270,18 @@ describe('parseRules', () => {
       expect(result[topSelector]).not.toHaveProperty(['color']);
     })
 
+    it('skips the rule entirely if the props value is false, undefined or null', () => {
+      const result = parseRulesNoDebug(topSelector, { kittensEverywhere: false }, {
+        fontSize: '10px',
+        [style.prop.kittensEverywhere]: {
+          color: 'purple'
+        }
+      });
+
+      expect(result).toHaveProperty([topSelector]);
+      expect(result[topSelector]).not.toHaveProperty(['color']);
+    })
+
     it('will render a block of styles for a block pattern', () => {
       const result = parseRulesNoDebug(
         topSelector,


### PR DESCRIPTION
I'm going to merge this one right away (since everyone is enjoying their weekends) but I wanted to make sure this change was still visible.

Basically, up until now, property patterns in shades have only ever checked for the existence of that property on the `props` object.  Even if the value is `null` or `false`, the pattern is considered a match, and the styles will be rendered.  This PR changes that to exclude `false` and `null` specifically from being considered matches, and will not render the styles.